### PR TITLE
R2.0/steven.wan/reservation checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ https://discordjs.guide/
 ### Installation
 1. Clone repository into a directory
 2. `cd` into directory and run `npm install`.
+3. `npm run setup.js` to run initial setup (create config.js)
 3. Verify keys are in config.js (and add the custom ones)
 4. `npm start` to start the bot.
 

--- a/commands/rank.js
+++ b/commands/rank.js
@@ -85,7 +85,7 @@ exports.run = async (client, message, args, level) => {
 
       // add data rows
       for(const data of sortedRanks) {
-        tableBoi.addRow([client.getUsername(data.userId), data.rank]);
+        tableBoi.addRow([client.getDiscordUsername(data.userId), data.rank]);
       }
 
       return message.channel.send(`\`\`\`

--- a/commands/rez.js
+++ b/commands/rez.js
@@ -1,0 +1,113 @@
+const enmap = require('enmap')
+const discord = require('discord.js')
+const rezClient = require('../modules/CampingReservationClient')
+
+exports.run = async (client, message, args, level) => {
+  const channel = message.channel
+  const author = message.author
+
+  const subcommand = args[0]
+  if(!subcommand) {
+    return sendHelp(channel)
+  }
+
+  const month = _getMonth(args[1])
+
+  switch(subcommand) {
+    case 'check':
+      await check(channel, month)
+      break
+    case 'watch':
+      await watch(client, channel, author, month)
+      break
+    case 'unwatch':
+      await unwatch(client, channel, author, month)
+      break
+    case 'watchlist':
+      await watchlist(client, channel, author)
+      break
+    default:
+      return sendHelp(channel)
+  }
+}
+
+async function check(channel, month) {
+  const reservations = await rezClient.getReservations(month)
+
+  if(reservations.size) {
+    channel.send(`\`\`\`
+${rezClient.getAsTable(reservations)}
+\`\`\``);
+  } else {
+    channel.send(`No reservations for month: ${month}`)
+  }
+}
+
+async function watch(client, channel, discordUser, month) {
+  const key = discordUser.id;
+  const userData = _getUserData(client, key)
+
+  if (!userData.monthsToCheck.includes(month)) {
+    client.rezData.push(key, month, "monthsToCheck", false)
+  }
+
+  _sendWatchList(client, channel, key)
+}
+
+async function unwatch(client, channel, discordUser, month) {
+  const key = discordUser.id;
+  const userData = _getUserData(client, key)
+
+  if (userData.monthsToCheck.includes(month)) {
+    client.rezData.remove(key, month, 'monthsToCheck')
+  }
+
+  _sendWatchList(client, channel, key)
+}
+
+async function watchlist(client, channel, discordUser) {
+  const key = discordUser.id;
+  _sendWatchList(client, channel, discordUser.id)
+}
+
+function _getUserData(client, userId) {
+  return client.rezData.ensure(userId, {
+    monthsToCheck: [],
+    userId: userId
+  })
+}
+
+function _getMonth(month) {
+  if(!month) {
+    month = new Date().getMonth() + 1
+  }
+
+  return month.toString().padStart(2, '0');
+}
+
+function _sendWatchList(client, channel, userId) {
+  channel.send(`Currently watching: ${_getUserData(client, userId).monthsToCheck}`)
+}
+
+function sendHelp(channel) {
+  return channel.send(`= USAGE =
+.rez check [month]   :: Displays the available reservations for the month
+.rez watch [month]   :: Start watching the given month for new reservations, you will get a DM when there are new reservations.
+.rez unwatch [month] :: Stop watching the given month
+.rez watchlist       :: Returns the months currently being watched`,
+  {code: 'asciidoc'});
+}
+
+exports.conf = {
+  enabled: true,
+  guildOnly: false,
+  aliases: [],
+  permLevel: "User"
+};
+
+exports.help = {
+  name: "rez",
+  category: "Miscellaneous",
+  description: "Gets current availability for campsite",
+  usage: "rez"
+};

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ client.aliases = new Enmap();
 // and makes things extremely easy for this purpose.
 client.settings = new Enmap({name: "settings"});
 
+// Data for Camping Reservation checker
+client.rezData = new Enmap({name: "rezData"});
+
 // We're doing real fancy node 8 async/await stuff here, and to do that
 // we need to wrap stuff in an anonymous function. It's annoying but it works.
 
@@ -61,12 +64,12 @@ const init = async () => {
     client.logger.log(`Loading Event: ${eventName}`);
     const event = require(`./events/${file}`);
     // Bind the client to any event, before the existing arguments
-    // provided by the discord.js event. 
+    // provided by the discord.js event.
     // This line is awesome by the way. Just sayin'.
     client.on(eventName, event.bind(null, client));
   });
 
-  // Then we load schedulables, which will include any background processes that need to run. 
+  // Then we load schedulables, which will include any background processes that need to run.
   const scheduler = new DiscordClientAwareScheduler(client)
   const schedulableFiles = await readdir("./schedulables");
   client.logger.log(`Loading a total of ${schedulableFiles.length} schedulables.`);

--- a/modules/CampingReservationClient.js
+++ b/modules/CampingReservationClient.js
@@ -1,0 +1,64 @@
+const bent = require('bent')
+const Bottleneck = require('bottleneck')
+const TableBoi = require("./TableBoi");
+const reservationClient = bent('https://www.recreation.gov/api/camps/availability/campground/', 'json', 200)
+const limiter = new Bottleneck({
+  minTime: 1000 // 1 request per second max
+})
+
+/*
+Example api response:
+
+    "campsites":{
+          "100":{
+             "availabilities":{
+                "2020-10-01T00:00:00Z":"Reserved",
+                "2020-10-02T00:00:00Z":"Available",
+                ...
+             },
+             "site":"044"
+          },
+          ...
+      }
+
+*/
+
+/* returns map of sites to the available days for that site. Only available sites are returned.
+    ex: {
+      "044": [11, 12, 13],
+      "045": [13]
+    }
+*/
+async function getReservations(month) {
+  const campgroundId = "232447";  // currently hard-coded to Yosemite's Upper Pines
+  var response = await reservationClient(`${campgroundId}/month?start_date=2020-${month}-01T00%3A00%3A00.000Z`);
+  return _checkCampsites(response.campsites);
+}
+
+function getAsTable(reservations) {
+  // convert date array to displayable string
+  const displayReservations = [...reservations].map(([site, dates]) => [site, dates.toString()])
+  return TableBoi.getTableString(["Site", "Dates"], displayReservations);
+}
+
+function _checkCampsites(campsites) {
+  var campsiteMap = new Map()
+
+  Object.entries(campsites).forEach(([id, campsite]) => {
+    const dates = _getAvailabeDates(campsite)
+    if(dates.length) {
+      campsiteMap.set(campsite.site, dates)
+    }
+  });
+
+  return new Map([...campsiteMap].sort())
+}
+
+function _getAvailabeDates(campsite) {
+  return Object.entries(campsite.availabilities)
+    .filter(([date, status]) => status === "Available")
+    .map(([date, status]) => new Date(date).getDate() + 1);
+}
+
+module.exports.getReservations = getReservations
+module.exports.getAsTable = getAsTable

--- a/modules/TableBoi.js
+++ b/modules/TableBoi.js
@@ -10,11 +10,24 @@
     +------------+----------+
 */
 class TableBoi {
+
+  /*
+   * Helper method to reduce boilerplate code
+   */
+  static getTableString(headers, rows) {
+    return new TableBoi(headers, rows).getTableString();
+  }
+
   /*
    * @param headers (required) list of column headers
+   * @param rows (optional)
    */
-  constructor(headers) {
+  constructor(headers, rows) {
     this.rows = [headers];
+
+    if(rows) {
+      this.rows.push(...rows);
+    }
   }
 
   /*
@@ -37,12 +50,12 @@ class TableBoi {
     });
 
     // generate horizontal separator
-    const horizontalSeparator = getHorizontalSeparatorStr(colLengths);
+    const horizontalSeparator = _getHorizontalSeparatorStr(colLengths);
 
     // generate each row and concatenate together
     let bodyStr = "";
     this.rows.forEach(function (row, index) {
-      bodyStr += getRowStr(colLengths, row, "|", " ");
+      bodyStr += _getRowStr(colLengths, row, "|", " ");
 
       // add horizontal separarator after header row
       if(index == 0) {
@@ -54,7 +67,7 @@ class TableBoi {
   }
 }
 
-function getRowStr(colLengths, rowVals, separator, filler) {
+function _getRowStr(colLengths, rowVals, separator, filler) {
   // get list of row values with necessary filler added
   const spacedVals = rowVals.map(function(val, index) {
     return filler + val + filler.repeat(colLengths[index] - val.length) + filler;
@@ -64,8 +77,8 @@ function getRowStr(colLengths, rowVals, separator, filler) {
   return separator + spacedVals.join(separator) + separator + "\n";
 }
 
-function getHorizontalSeparatorStr(colLengths) {
-  return getRowStr(colLengths, new Array(colLengths.length).fill(""), "+", "-");
+function _getHorizontalSeparatorStr(colLengths) {
+  return _getRowStr(colLengths, new Array(colLengths.length).fill(""), "+", "-");
 }
 
 module.exports = TableBoi;

--- a/schedulables/ReservationAvailabilityPoller.js
+++ b/schedulables/ReservationAvailabilityPoller.js
@@ -1,0 +1,78 @@
+const enmap = require('enmap')
+const discord = require('discord.js')
+const rezClient = require('../modules/CampingReservationClient')
+var _ = require('underscore')
+const { conf } = require('../commands/dota')
+const TableBoi = require("../modules/TableBoi");
+
+// reservations from previous run, used to figure out the new reservations
+const previousReservations = new Map()
+
+function getNewReservations(month, reservations) {
+  const previousReservationsForMonth = previousReservations.get(month)
+  previousReservations.set(month, reservations)
+
+  if(!previousReservationsForMonth) {
+    return reservations // first run
+  }
+
+  // remove the sites where the dates haven't changed
+  const newReservations = new Map(reservations)
+  newReservations.forEach((currentDates, site, map) => {
+    const previousDates = previousReservationsForMonth.get(site);
+    if(!_.difference(currentDates, previousDates).length) {
+      map.delete(site)
+    }
+  })
+
+  return newReservations
+}
+
+// return map of months to the users watching that month
+function getMonthsToWatchers(client) {
+  const monthsToUsers = new Map()
+
+  client.rezData.forEach((entry) => {
+    entry.monthsToCheck.forEach((month) => {
+      if(!monthsToUsers.has(month)) {
+        monthsToUsers.set(month, [entry.userId])
+      } else {
+        monthsToUsers.get(month).push(entry.userId)
+      }
+    })
+  })
+
+  return monthsToUsers
+}
+
+module.exports.run = async (client) => {
+  const monthsToWatchers = getMonthsToWatchers(client)
+  const monthsToCheck = [...monthsToWatchers.keys()]
+
+  console.log(`Checking: [${monthsToCheck}]`)
+
+  for (const month of monthsToCheck) {
+    // Check availability in month and get new availabilities
+    const reservations = await rezClient.getReservations(month);
+    const newReservations = getNewReservations(month, reservations)
+
+    // notify watchers
+    if(newReservations.size) {
+      const newTable = rezClient.getAsTable(newReservations)
+      const watchers = monthsToWatchers.get(month).map(userId => client.users.cache.get(userId))
+
+      console.log(`Notifying [${watchers.length}] watchers about [${month}]`)
+
+      for(const watcher of watchers) {
+        watcher.send(`\`\`\`
+New reservations for [${month}]:
+${newTable}
+\`\`\``);
+      }
+    }
+  }
+}
+
+module.exports.conf = {
+  cron: '*/30 * * * * *'  // every 30 seconds
+}


### PR DESCRIPTION
**Summary**:
Calls the national park camping reservation endpoint to check for openings, and notifies users via DM when there are new ones.

**Todo:**
- Currently only checks one hard-coded campground (Yosemite Upper Pines).  Need to let uses specify their own campgrounds to check
- Maybe something to automatically unwatch old months

**Commands**:
![image](https://user-images.githubusercontent.com/711330/93028780-fc1a4380-f5ca-11ea-94c0-69ccf29e92a1.png)


**Example** DM: 
![image](https://user-images.githubusercontent.com/711330/93028769-ec026400-f5ca-11ea-80ce-45aa6cd3b286.png)
